### PR TITLE
Use https for plotly-latest.min.js

### DIFF
--- a/peddy/tmpl.html
+++ b/peddy/tmpl.html
@@ -9,7 +9,7 @@
  <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/rangeslider.js/2.1.1/rangeslider.min.css">
  <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/buttons/1.2.2/css/buttons.dataTables.min.css">
 
- <script src="http://cdn.plot.ly/plotly-latest.min.js"></script>
+ <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
  <script src="https://code.jquery.com/jquery-1.12.0.min.js"></script>
 
  <script src="https://cdn.datatables.net/1.10.11/js/jquery.dataTables.min.js"></script>


### PR DESCRIPTION
Hi, this is a great project thank you.

Would it be possible to change the template to use https for plotly-latest.min.js please (consistent with all of the other js scripts)? Currently if I serve a peddy report via our internal https only server this causes browsers to display "insecure content warnings".

Thanks.