### PR TITLE
Adapt to networkx >=2.0 which dropped *_iter() methods.

### DIFF
--- a/peddy/peddy.py
+++ b/peddy/peddy.py
@@ -77,7 +77,7 @@ def lowest_common_ancestors(G, targets):
             n = q.popleft()
             if n in parents:
                 continue
-            for p in G.successors_iter(n):
+            for p in G.successors(n):
                 q.append(p)
             parents.add(n)
 
@@ -91,7 +91,7 @@ def lowest_common_ancestors(G, targets):
     lowest_common = set()
     if common_ancestors is not None:
         for p in common_ancestors:
-            if any(child not in common_ancestors and child in all_ancestors for child in G.predecessors_iter(p)):
+            if any(child not in common_ancestors and child in all_ancestors for child in G.predecessors(p)):
                 lowest_common.add(p)
 
     return lowest_common


### PR DESCRIPTION
NetworkX dropped the _iter() methods in version 2.0.0; the default predecessor and successor methods return iterators now. Regarding backwards compatibility, I think this change should also work with earlier methods which returned lists, but I haven't tested it.